### PR TITLE
Add menu:show() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ menu. The second and third parameters are not mandatory, the defaults are
 parameter. However, it wont correctly place "context" menu as it have no idea
 where you expect them. It work better with "box" menus.
 
+You can also show a menu from your own `buttons` callback, like so:
+
+```lua
+    widget:buttons(awful.util.table.join(
+        awful.button({}, 3, function(geometry)
+            menu:show{ geometry=geometry, show=not menu.visible }
+        end),
+    ))
+```
+
+If you want to manually show a menu from a point where you do not have direct
+access to the widget geometry, you have to provide the wibox in which the
+widget resides:
+
+```lua
+    menu:show{ wibox=wibox, widget=widget }
+```
+
+If you don't provide the `wibox`, radical will try to guess one but this may
+very well fail.
+
+
 ### Menu types
 
 The current valid types are:

--- a/init.lua
+++ b/init.lua
@@ -49,10 +49,7 @@ local function set_menu(self,menu, event, button_id, mode)
     end
     if not m then return end
 
-    m.parent_geometry = geo
-    m._internal.w:move_by_parent(geo, mode)
-
-    m.visible = not m.visible
+    m:show{ geometry=geo, mode=mode, show=not m.visible }
   end
 
   if event == "button::pressed" then


### PR DESCRIPTION
This adds a show() method that allows showing menus manually for a given widget.

Since this adds some code relying on awesome implementation details I can fully understand if you reject.

Best, Thomas